### PR TITLE
Allow arbitrary annotations on Jupyterhub hub-secret

### DIFF
--- a/charts/jupyterhub/templates/hub/secret.yaml
+++ b/charts/jupyterhub/templates/hub/secret.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hub-secret
   labels:
     {{- include "jupyterhub.labels" . | nindent 4 }}
+  annotations:
+    {{- .Values.hub.secret.annotations | toYaml | trimSuffix "\n" | nindent 4 }}
 type: Opaque
 data:
   {{- $values := merge dict .Values }}

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -106,6 +106,8 @@ hub:
   authenticatePrometheus:
   redirectToServer:
   shutdownOnLogout:
+  secret:
+    annotations: {}
   templatePaths: []
   templateVars: {}
   livenessProbe:


### PR DESCRIPTION
This is primarily to allow Bank Vaults to read and interpolate the hub
secret value that gets injected into that secret
