### PR TITLE
Adding features for secrets in proxy.token

### DIFF
--- a/charts/jupyterhub/templates/hub/deployment.yaml
+++ b/charts/jupyterhub/templates/hub/deployment.yaml
@@ -156,11 +156,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if eq .Values.proxy.secretType "default"}}
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.hub.existingSecret | default "hub-secret" }}
                   key: proxy.token
+            {{- end}}
             {{- if .Values.auth.state.enabled }}
             - name: JUPYTERHUB_CRYPT_KEY
               valueFrom:

--- a/charts/jupyterhub/templates/hub/secret.yaml
+++ b/charts/jupyterhub/templates/hub/secret.yaml
@@ -15,8 +15,13 @@ data:
   {{- $_ := set $values "Release" (pick .Release "Name" "Namespace" "Service") }}
   values.yaml: {{ $values | toYaml | b64enc | quote }}
 
+  {{- if eq .Values.proxy.secretType "default"}}
   # Used to mount CONFIGPROXY_AUTH_TOKEN on hub/proxy pods for mutual trust
   proxy.token: {{ .Values.proxy.secretToken | required "Proxy token must be a 32 byte random string generated with `openssl rand -hex 32`!" | b64enc | quote }}
+  {{- else}}
+  # keeping this here for compatability
+  proxy.token: {{ .Values.proxy.secretToken | default "" }}
+  {{- end }}
 
   {{- with .Values.hub.db.password }}
   # Used to mount MYSQL_PWD or PGPASSWORD on hub pod

--- a/charts/jupyterhub/templates/proxy/deployment.yaml
+++ b/charts/jupyterhub/templates/proxy/deployment.yaml
@@ -92,11 +92,13 @@ spec:
           resources:
             {{- .Values.proxy.chp.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           env:
+            {{- if eq .Values.proxy.secretType "default"}}
             - name: CONFIGPROXY_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.hub.existingSecret | default "hub-secret" }}
                   key: proxy.token
+            {{- end}}
             {{- include "jupyterhub.extraEnv" .Values.proxy.chp.extraEnv | nindent 12 }}
           {{- with .Values.proxy.chp.image.pullPolicy }}
           imagePullPolicy: {{ . }}

--- a/charts/jupyterhub/values.yaml
+++ b/charts/jupyterhub/values.yaml
@@ -130,6 +130,7 @@ rbac:
 # pod and proxy-http service.
 proxy:
   secretToken: ''
+  secretType: default
   annotations: {}
   deploymentStrategy:
     ## type: Recreate


### PR DESCRIPTION
This feature provides a toggle for including secrets for the proxy token and is an incremental change toward adding options to provide the proxy token by alternative, vault-friendly means.